### PR TITLE
Add a function which returns textual name of HTTP method

### DIFF
--- a/src/native/api.c
+++ b/src/native/api.c
@@ -117,6 +117,16 @@ const char* llhttp_errno_name(llhttp_errno_t err) {
 }
 
 
+const char* llhttp_method_name(llhttp_method_t method) {
+#define HTTP_METHOD_GEN(NUM, NAME, STRING) case HTTP_##NAME: return #STRING;
+  switch (method) {
+    HTTP_METHOD_MAP(HTTP_METHOD_GEN)
+    default: abort();
+  }
+#undef HTTP_METHOD_GEN
+}
+
+
 /* Callbacks */
 
 

--- a/src/native/api.h
+++ b/src/native/api.h
@@ -133,6 +133,9 @@ const char* llhttp_get_error_pos(const llhttp_t* parser);
 /* Returns textual name of error code */
 const char* llhttp_errno_name(llhttp_errno_t err);
 
+/* Returns textual name of HTTP method */
+const char* llhttp_method_name(llhttp_method_t method);
+
 #ifdef __cplusplus
 }  /* extern "C" */
 #endif


### PR DESCRIPTION
This change adds a function which returns text name of the given HTTP method.

Fixes #6 
